### PR TITLE
[INFRA] Use Webpack instead of Parcel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "errobj",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "☠️ Serialise errors to literal (JSONable) object",
   "keywords": [
     "error-logger",
@@ -24,7 +24,7 @@
   "scripts": {
     "test": "mocha **/spec.js",
     "lint": "eslint . --ext .js",
-    "build": "parcel build 'index.js' --out-dir 'dist'",
+    "build": "webpack",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
@@ -36,6 +36,7 @@
     "eslint": "^7.8.0",
     "eslint-plugin-log": "^1.2.4",
     "mocha": "^9.1.0",
-    "parcel-bundler": "^1.12.4"
+    "webpack": "^5.67.0",
+    "webpack-cli": "^4.9.2"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+	mode: 'production',
+	entry: './index.js',
+	output: {
+		filename: 'index.js',
+		library: {
+			type: 'commonjs2',
+		},
+	},
+	devtool: 'source-map',
+};


### PR DESCRIPTION
## Description

When I build my package (which consume `errobj`) for the browser (using webpack) I am getting a warning:
```
WARNING in ./node_modules/errobj/dist/index.js 1:292-296
Critical dependency: the request of a dependency is an expression
```
I tried to understand why, but it stays unclear for me.

I paid attention that if I build `errobj` with webpack instead of parcel, this warning disappear.

*conclusion:* I propose to migrate from parcel to webpack.

Maybe you are aware about this issue and have some ideas to fix it more properly?

## How to reproduce
I created a new npm package locally.
```
$ nvm use 14
$ npm init --y
$ npm i webpack webpack-cli errobj
$ touch webpack.config.json
$ touch index.js
```

#### `index.js`
```
import errobj from 'errobj';
console.log(errobj(new Error('OooOOOOoOOOooOOOps'));)
```
#### `webpack.config.json`
```
module.exports = { entry: './index.js' }
```

```
$ webpack
```

### Output:
```
asset main.js 14.2 KiB [compared for emit] (name: main)
runtime modules 937 bytes 4 modules
built modules 9 KiB [built]
  ./index.js 83 bytes [built] [code generated]
  ./node_modules/errobj/dist/index.js 8.77 KiB [built] [code generated]
  ./node_modules/errobj/dist/ sync 160 bytes [built] [code generated]

WARNING in ./node_modules/errobj/dist/index.js 1:292-296
Critical dependency: the request of a dependency is an expression
 @ ./index.js 1:0-28 2:12-18

1 warning has detailed information that is not shown.
Use 'stats.errorDetails: true' resp. '--stats-error-details' to show it.

webpack 5.67.0 compiled with 1 warning in 147 ms
```