### PR TITLE
Remove bundled dist

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 .*
 *.log
+*.md
 spec.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Change Log
+
+## 3.0.0
+- Breaking: Remove bundled "browser" entry. If you are transpiling for the browser please do not exclude this package.
+- Otherwise - no code changes.
+
+## 2.4.1
+- [FIX] Don't add cause field when cause is undefined
+
+## 2.4.0
+- Support error.cause, add "description" custom field
+
+## 2.3.0
+- Add more fields to error
+
+## 2.2.1
+- Move repo - no change
+
+## 2.2.0
+- Support error.toJSON
+
+## 2.1.0
+- Parsed stack specific depth instead of just with or without
+
+## 2.0.0
+- Breaking: parsedStack is not attached by default
+- Add stack offset
+
+## 1.0.0
+- Stabailse package - no change
+
+## 0.0.0
+- Serialise errors to literal (JSONable) object

--- a/index.js
+++ b/index.js
@@ -40,7 +40,6 @@ function errobj(error, enrichment = {}, { offset = 0, parsedStack = 0 } = {}) {
 	);
 }
 
-
 /**
  * @param {Error} error
  * @returns {string}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "errobj",
-  "version": "2.4.1",
+  "version": "3.0.0",
   "description": "☠️ Serialise errors to literal (JSONable) object",
   "keywords": [
     "error-logger",
@@ -20,12 +20,9 @@
   "homepage": "https://omrilotan.com/errobj/",
   "type": "commonjs",
   "main": "index.js",
-  "browser": "dist/index.js",
   "scripts": {
     "test": "mocha **/spec.js",
-    "lint": "eslint . --ext .js",
-    "build": "parcel build 'index.js' --out-dir 'dist'",
-    "prepublishOnly": "npm run build"
+    "lint": "eslint . --ext .js"
   },
   "dependencies": {
     "error-stack-parser": "^2.0.6"
@@ -33,9 +30,9 @@
   "devDependencies": {
     "@omrilotan/eslint-config": "^1.3.0",
     "chai": "^4.2.0",
-    "eslint": "^7.8.0",
+    "eslint": "^8.7.0",
+    "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-log": "^1.2.4",
-    "mocha": "^9.1.0",
-    "parcel-bundler": "^1.12.4"
+    "mocha": "^9.1.0"
   }
 }


### PR DESCRIPTION
**Breaking**: browser entry is no longer available

Allow transpilers to choose their own way to bundle this package.

Replaces #19 