### PR TITLE
Babel support for es5.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.4.3
+- Add `babel` and ensure bundle is `es5` compliance.
+
 ## 2.4.2
 - Replace parcel build with webpack
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "errobj",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "☠️ Serialise errors to literal (JSONable) object",
   "keywords": [
     "error-logger",
@@ -31,7 +31,10 @@
     "error-stack-parser": "^2.0.6"
   },
   "devDependencies": {
+    "@babel/core": "^7.16.12",
+    "@babel/preset-env": "^7.16.11",
     "@omrilotan/eslint-config": "^1.3.0",
+    "babel-loader": "^8.2.3",
     "chai": "^4.2.0",
     "eslint": "^8.8.0",
     "eslint-plugin-log": "^1.2.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,11 +1,26 @@
 module.exports = {
 	mode: 'production',
 	entry: './index.js',
+	target: ['web', 'es5'],
 	output: {
 		filename: 'index.js',
 		library: {
 			type: 'commonjs2',
-		},
+		}
+	},
+	module: {
+		rules: [
+			{
+				test: /\.m?js$/,
+				exclude: /(node_modules)/,
+				use: {
+					loader: 'babel-loader',
+					options: {
+						presets: ['@babel/preset-env']
+					}
+				}
+			}
+		]
 	},
 	devtool: 'source-map',
 };


### PR DESCRIPTION
Since this package was added webpack, it's not ES5 compliance (Webpack 5 default ecma target is es6).

This PR add babel to ensure code gets compiled to es5 + Adding webpack target `es5` to ensure it's wrapper would fit as-well.