### PR TITLE
[fix] Parse error.cause to object, not a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.0.1
+
+- Fix: error.cause should remain its original structure instead of being "stringified"
+
 ## 3.0.0
 
 - New builds for commonjs and esm

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "errobj",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "☠️ Serialise errors to literal (JSONable) object",
   "keywords": [
     "error-logger",

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ function getCause(error: Error): string | undefined {
 		if (cause === error) {
 			cause = "[Circular]";
 		} else {
-			cause = JSON.stringify(errobj(cause));
+			cause = errobj(cause);
 		}
 	}
 

--- a/src/test.ts
+++ b/src/test.ts
@@ -182,9 +182,7 @@ at HTMLIFrameElement.b (https://connect.facebook.net/en_US/fbevents.js:24:3061)`
 		const error = new Error("Something must have gone terribly wrong", {
 			cause: err,
 		});
-		const original = errobj(err);
-		const { cause } = errobj(error);
-		expect(cause).toBe(JSON.stringify(original));
+		expect(errobj(error.cause as Error)).toEqual(errobj(err));
 	});
 	it("should escape circular reference in cause", (): void => {
 		const error = new Error("Something must have gone terribly wrong");


### PR DESCRIPTION
This parsing is considered incorrect behaviour.